### PR TITLE
added unit tests

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,12 @@
+{
+    "presets": [
+        [
+            "@babel/preset-env",
+            {
+                "targets": {
+                    "node": "current"
+                }
+            }
+        ]
+    ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: node_js
+node_js:
+- node
+cache:
+  directories:
+  - node_modules
+deploy:
+  provider: npm
+  email: heaper@gmail.com
+  api_key:
+    secure: tlI6hBUOMvyIFqobLAJTTVfwVh0M2gs6uPHn1R2cYV99pDr8ymF8WtFUTMcascnUZ5ujqExKQn74pYTwRy2SZJsJQiavTeSE27sVYktNceZPof5WL0LLxeBOssxFL12M5Oz47wuNEj/CR9oNq1k7ax6eo/9aDWOS6VvhmwOVm8mfGyUKUOwqx22B6/Xub2q2ApHAxVxI1pr+aL3k2XL+eMZHp6FuBR+DS6Z/hgPlLFKqsk4q9bcDlrXQfCfzRBxFbP4XtC/4PdA9p86kd3eIouVPDRqI+i4DMZB0+K7wMeK8l3YfaAPW2vssnQKFLFF8Rgt5SUAU+0axX0HUDSIIal7oeJKFWjOlhM/N6ugtFZAdsZFNL/hQ/GPQ22oFqICD3xZpzchPbzQODp3XIjQcu//aAc/+x0sCzeGbsO+EN0rWMUfztEQoeR8RFwnNIcbrXbP6s6UquCZXvI98cONxuu3rW0uOUQB811LUZpf26DsQv7dS1YWFu8a/dVO8yW62QwqrFfLPxAUEBBWUiT8z735jT2Tu+HIkq7j25j4IBMSrcQAwp3zu1qC7ISypmSbjG8d5QaavjFV7m4j8uwHdDWnbERIZTJonzQcMgFiIczB9SaBAt4Pq3Gfel8llxYEkFxns7qYSdX6s+E7MkVH6239yLb5YSdRvYMtApCcMG2M=
+  on:
+    branch: master
+    tags: true
+    repo: DEGJS/easing

--- a/README.md
+++ b/README.md
@@ -1,18 +1,20 @@
 # Easing
+[![Build Status](https://travis-ci.org/DEGJS/easing.svg?branch=master)](https://travis-ci.org/DEGJS/easing)
+
 A collection of animation easing functions in Javascript's ES6 module format. Easing functions specify the rate of change of a parameter over time. Learn more about easing [here](https://developers.google.com/web/fundamentals/design-and-ui/animations/the-basics-of-easing?hl=en).
 
 ## Install
-Easing is an ES6 module. Consequently, you'll need an ES6 transpiler ([Babel](https://babeljs.io) is a nice one) and a module loader ([SystemJS](https://github.com/systemjs/systemjs) will do the job) as part of your Javascript workflow.
+Easing is an ES module. If your runtime environment does not support ES modules, you'll need a transpiler ([Babel](https://babeljs.io) is a nice one).
 
-If you're already using the [JSPM package manager](http://jspm.io) for your project, you can install Easing with the following command:
+If you're using NPM, you can install Easing with the following command:
 
 ```
-$ jspm install github:DEGJS/easing
+$ npm install @degjs/easing
 ```
 
 ## Usage
 ```js
-import { easeInOutCubic } from 'DEGJS/easing';
+import { easeInOutCubic } from '@degjs/easing';
 
 // animate a value from 100 to 300 with ease-in-out easing over the course of 1 second
 let currentIteration = 0,
@@ -57,6 +59,3 @@ Starts quickly and ends slowly.
 Starts slowly and ends quickly.
 ### .easeInOutCubic(currentIteration, startValue, changeInValue, totalIterations)
 Starts and ends slowly. 
-## Browser Support
-
-Easing does not depend on any special browser APIs and should work with all browsers.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1304 @@
+{
+    "name": "@degjs/easing",
+    "version": "2.0.0",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "@babel/code-frame": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+            "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+            "dev": true,
+            "requires": {
+                "@babel/highlight": "^7.0.0"
+            }
+        },
+        "@babel/core": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.0.0.tgz",
+            "integrity": "sha512-nrvxS5u6QUN5gLl1GEakIcmOeoUHT1/gQtdMRq18WFURJ5osn4ppJLVSseMQo4zVWKJfBTF4muIYijXUnKlRLQ==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@babel/generator": "^7.0.0",
+                "@babel/helpers": "^7.0.0",
+                "@babel/parser": "^7.0.0",
+                "@babel/template": "^7.0.0",
+                "@babel/traverse": "^7.0.0",
+                "@babel/types": "^7.0.0",
+                "convert-source-map": "^1.1.0",
+                "debug": "^3.1.0",
+                "json5": "^0.5.0",
+                "lodash": "^4.17.10",
+                "resolve": "^1.3.2",
+                "semver": "^5.4.1",
+                "source-map": "^0.5.0"
+            }
+        },
+        "@babel/generator": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0.tgz",
+            "integrity": "sha512-/BM2vupkpbZXq22l1ALO7MqXJZH2k8bKVv8Y+pABFnzWdztDB/ZLveP5At21vLz5c2YtSE6p7j2FZEsqafMz5Q==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.0.0",
+                "jsesc": "^2.5.1",
+                "lodash": "^4.17.10",
+                "source-map": "^0.5.0",
+                "trim-right": "^1.0.1"
+            }
+        },
+        "@babel/helper-annotate-as-pure": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
+            "integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-builder-binary-assignment-operator-visitor": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.0.0.tgz",
+            "integrity": "sha512-9HdU8lrAc4FUZOy+y2w//kUhynSpkGIRYDzJW1oKJx7+v8m6UEAbAd2tSvxirsq2kJTXJZZS6Eo8FnUDUH0ZWw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-explode-assignable-expression": "^7.0.0",
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-call-delegate": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.0.0.tgz",
+            "integrity": "sha512-HdYG6vr4KgXHK0q1QRZ8guoYCF5rZjIdPlhcVY+j4EBK/FDR+cXRM5/6lQr3NIWDc7dO1KfgjG5rfH6lM89VBw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-hoist-variables": "^7.0.0",
+                "@babel/traverse": "^7.0.0",
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-define-map": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.0.0.tgz",
+            "integrity": "sha512-acbCxYS9XufWxsBiclmXMK1CFz7en/XSYvHFcbb3Jb8BqjFEBrA46WlIsoSQTRG/eYN60HciUnzdyQxOZhrHfw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-function-name": "^7.0.0",
+                "@babel/types": "^7.0.0",
+                "lodash": "^4.17.10"
+            }
+        },
+        "@babel/helper-explode-assignable-expression": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.0.0.tgz",
+            "integrity": "sha512-5gLPwdDnYf8GfPsjS+UmZUtYE1jaXTFm1P+ymGobqvXbA0q3ANgpH60+C6zDrRAWXYbQXYvzzQC/r0gJVNNltQ==",
+            "dev": true,
+            "requires": {
+                "@babel/traverse": "^7.0.0",
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-function-name": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0.tgz",
+            "integrity": "sha512-Zo+LGvfYp4rMtz84BLF3bavFTdf8y4rJtMPTe2J+rxYmnDOIeH8le++VFI/pRJU+rQhjqiXxE4LMaIau28Tv1Q==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-get-function-arity": "^7.0.0",
+                "@babel/template": "^7.0.0",
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-get-function-arity": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+            "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-hoist-variables": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0.tgz",
+            "integrity": "sha512-Ggv5sldXUeSKsuzLkddtyhyHe2YantsxWKNi7A+7LeD12ExRDWTRk29JCXpaHPAbMaIPZSil7n+lq78WY2VY7w==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-member-expression-to-functions": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0.tgz",
+            "integrity": "sha512-avo+lm/QmZlv27Zsi0xEor2fKcqWG56D5ae9dzklpIaY7cQMK5N8VSpaNVPPagiqmy7LrEjK1IWdGMOqPu5csg==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-module-imports": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
+            "integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-module-transforms": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.0.0.tgz",
+            "integrity": "sha512-QdwmTTlPmT7TZcf30dnqm8pem+o48tVt991xXogE5CQCwqSpWKuzH2E9v8VWeccQ66a6/CmrLZ+bwp66JYeM5A==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-imports": "^7.0.0",
+                "@babel/helper-simple-access": "^7.0.0",
+                "@babel/helper-split-export-declaration": "^7.0.0",
+                "@babel/template": "^7.0.0",
+                "@babel/types": "^7.0.0",
+                "lodash": "^4.17.10"
+            }
+        },
+        "@babel/helper-optimise-call-expression": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz",
+            "integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-plugin-utils": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
+            "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
+            "dev": true
+        },
+        "@babel/helper-regex": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0.tgz",
+            "integrity": "sha512-TR0/N0NDCcUIUEbqV6dCO+LptmmSQFQ7q70lfcEB4URsjD0E1HzicrwUH+ap6BAQ2jhCX9Q4UqZy4wilujWlkg==",
+            "dev": true,
+            "requires": {
+                "lodash": "^4.17.10"
+            }
+        },
+        "@babel/helper-remap-async-to-generator": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.0.0.tgz",
+            "integrity": "sha512-3o4sYLOsK6m0A7t1P0saTanBPmk5MAlxVnp9773Of4L8PMVLukU7loZix5KoJgflxSo2c2ETTzseptc0rQEp7A==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-annotate-as-pure": "^7.0.0",
+                "@babel/helper-wrap-function": "^7.0.0",
+                "@babel/template": "^7.0.0",
+                "@babel/traverse": "^7.0.0",
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-replace-supers": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.0.0.tgz",
+            "integrity": "sha512-fsSv7VogxzMSmGch6DwhKHGsciVXo7hbfhBgH9ZrgJMXKMjO7ASQTUfbVL7MU1uCfviyqjucazGK7TWPT9weuQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-member-expression-to-functions": "^7.0.0",
+                "@babel/helper-optimise-call-expression": "^7.0.0",
+                "@babel/traverse": "^7.0.0",
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-simple-access": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.0.0.tgz",
+            "integrity": "sha512-CNeuX52jbQSq4j1n+R+21xrjbTjsnXa9n1aERbgHRD/p9h4Udkxr1n24yPMQmnTETHdnQDvkVSYWFw/ETAymYg==",
+            "dev": true,
+            "requires": {
+                "@babel/template": "^7.0.0",
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-split-export-declaration": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
+            "integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-wrap-function": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.0.0.tgz",
+            "integrity": "sha512-kjprWPDNVPZ/9pyLRXcZBvfjnFwqokmXTPTaC4AV8Ns7WRl7ewSxrB19AWZzQsC/WSPQLOw1ciR8uPYkAM1znA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-function-name": "^7.0.0",
+                "@babel/template": "^7.0.0",
+                "@babel/traverse": "^7.0.0",
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helpers": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.0.0.tgz",
+            "integrity": "sha512-jbvgR8iLZPnyk6m/UqdXYsSxbVtRi7Pd3CzB4OPwPBnmhNG1DWjiiy777NTuoyIcniszK51R40L5pgfXAfHDtw==",
+            "dev": true,
+            "requires": {
+                "@babel/template": "^7.0.0",
+                "@babel/traverse": "^7.0.0",
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/highlight": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+            "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.0.0",
+                "esutils": "^2.0.2",
+                "js-tokens": "^4.0.0"
+            }
+        },
+        "@babel/parser": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0.tgz",
+            "integrity": "sha512-RgJhNdRinpO8zibnoHbzTTexNs4c8ROkXFBanNDZTLHjwbdLk8J5cJSKulx/bycWTLYmKVNCkxRtVCoJnqPk+g==",
+            "dev": true
+        },
+        "@babel/plugin-proposal-async-generator-functions": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.0.0.tgz",
+            "integrity": "sha512-QsXmmjLrFADCcDQAfdQn7tfBRLjpTzRWaDpKpW4ZXW1fahPG4SvjcF1xfvVnXGC662RSExYXL+6DAqbtgqMXeA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-remap-async-to-generator": "^7.0.0",
+                "@babel/plugin-syntax-async-generators": "^7.0.0"
+            }
+        },
+        "@babel/plugin-proposal-json-strings": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.0.0.tgz",
+            "integrity": "sha512-kfVdUkIAGJIVmHmtS/40i/fg/AGnw/rsZBCaapY5yjeO5RA9m165Xbw9KMOu2nqXP5dTFjEjHdfNdoVcHv133Q==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/plugin-syntax-json-strings": "^7.0.0"
+            }
+        },
+        "@babel/plugin-proposal-object-rest-spread": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0.tgz",
+            "integrity": "sha512-14fhfoPcNu7itSen7Py1iGN0gEm87hX/B+8nZPqkdmANyyYWYMY2pjA3r8WXbWVKMzfnSNS0xY8GVS0IjXi/iw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/plugin-syntax-object-rest-spread": "^7.0.0"
+            }
+        },
+        "@babel/plugin-proposal-optional-catch-binding": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.0.0.tgz",
+            "integrity": "sha512-JPqAvLG1s13B/AuoBjdBYvn38RqW6n1TzrQO839/sIpqLpbnXKacsAgpZHzLD83Sm8SDXMkkrAvEnJ25+0yIpw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/plugin-syntax-optional-catch-binding": "^7.0.0"
+            }
+        },
+        "@babel/plugin-proposal-unicode-property-regex": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.0.0.tgz",
+            "integrity": "sha512-tM3icA6GhC3ch2SkmSxv7J/hCWKISzwycub6eGsDrFDgukD4dZ/I+x81XgW0YslS6mzNuQ1Cbzh5osjIMgepPQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-regex": "^7.0.0",
+                "regexpu-core": "^4.2.0"
+            }
+        },
+        "@babel/plugin-syntax-async-generators": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0.tgz",
+            "integrity": "sha512-im7ged00ddGKAjcZgewXmp1vxSZQQywuQXe2B1A7kajjZmDeY/ekMPmWr9zJgveSaQH0k7BcGrojQhcK06l0zA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-syntax-json-strings": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.0.0.tgz",
+            "integrity": "sha512-UlSfNydC+XLj4bw7ijpldc1uZ/HB84vw+U6BTuqMdIEmz/LDe63w/GHtpQMdXWdqQZFeAI9PjnHe/vDhwirhKA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-syntax-object-rest-spread": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0.tgz",
+            "integrity": "sha512-5A0n4p6bIiVe5OvQPxBnesezsgFJdHhSs3uFSvaPdMqtsovajLZ+G2vZyvNe10EzJBWWo3AcHGKhAFUxqwp2dw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-syntax-optional-catch-binding": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.0.0.tgz",
+            "integrity": "sha512-Wc+HVvwjcq5qBg1w5RG9o9RVzmCaAg/Vp0erHCKpAYV8La6I94o4GQAmFYNmkzoMO6gzoOSulpKeSSz6mPEoZw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-arrow-functions": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0.tgz",
+            "integrity": "sha512-2EZDBl1WIO/q4DIkIp4s86sdp4ZifL51MoIviLY/gG/mLSuOIEg7J8o6mhbxOTvUJkaN50n+8u41FVsr5KLy/w==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-async-to-generator": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.0.0.tgz",
+            "integrity": "sha512-CiWNhSMZzj1n3uEKUUS/oL+a7Xi8hnPQB6GpC1WfL/ZYvxBLDBn14sHMo5EyOaeArccSonyk5jFIKMRRbrHOnQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-imports": "^7.0.0",
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-remap-async-to-generator": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-block-scoped-functions": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.0.0.tgz",
+            "integrity": "sha512-AOBiyUp7vYTqz2Jibe1UaAWL0Hl9JUXEgjFvvvcSc9MVDItv46ViXFw2F7SVt1B5k+KWjl44eeXOAk3UDEaJjQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-block-scoping": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0.tgz",
+            "integrity": "sha512-GWEMCrmHQcYWISilUrk9GDqH4enf3UmhOEbNbNrlNAX1ssH3MsS1xLOS6rdjRVPgA7XXVPn87tRkdTEoA/dxEg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "lodash": "^4.17.10"
+            }
+        },
+        "@babel/plugin-transform-classes": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.0.0.tgz",
+            "integrity": "sha512-8LBm7XsHQiNISEmb+ejBiHi1pUihwUf+lrIwyVsXVbQ1vLqgkvhgayK5JnW3WXvQD2rmM0qxFAIyDE5vtMem2A==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-annotate-as-pure": "^7.0.0",
+                "@babel/helper-define-map": "^7.0.0",
+                "@babel/helper-function-name": "^7.0.0",
+                "@babel/helper-optimise-call-expression": "^7.0.0",
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-replace-supers": "^7.0.0",
+                "@babel/helper-split-export-declaration": "^7.0.0",
+                "globals": "^11.1.0"
+            }
+        },
+        "@babel/plugin-transform-computed-properties": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0.tgz",
+            "integrity": "sha512-ubouZdChNAv4AAWAgU7QKbB93NU5sHwInEWfp+/OzJKA02E6Woh9RVoX4sZrbRwtybky/d7baTUqwFx+HgbvMA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-destructuring": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.0.0.tgz",
+            "integrity": "sha512-Fr2GtF8YJSXGTyFPakPFB4ODaEKGU04bPsAllAIabwoXdFrPxL0LVXQX5dQWoxOjjgozarJcC9eWGsj0fD6Zsg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-dotall-regex": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.0.0.tgz",
+            "integrity": "sha512-00THs8eJxOJUFVx1w8i1MBF4XH4PsAjKjQ1eqN/uCH3YKwP21GCKfrn6YZFZswbOk9+0cw1zGQPHVc1KBlSxig==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-regex": "^7.0.0",
+                "regexpu-core": "^4.1.3"
+            }
+        },
+        "@babel/plugin-transform-duplicate-keys": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.0.0.tgz",
+            "integrity": "sha512-w2vfPkMqRkdxx+C71ATLJG30PpwtTpW7DDdLqYt2acXU7YjztzeWW2Jk1T6hKqCLYCcEA5UQM/+xTAm+QCSnuQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-exponentiation-operator": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.0.0.tgz",
+            "integrity": "sha512-Ig74elCuFQ0mvHkWUq5qDCNI3qHWlop5w4TcDxdtJiOk8Egqe2uxDRY9XnXGSlmWClClmnixcoYumyvbAuj4dA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-builder-binary-assignment-operator-visitor": "^7.0.0",
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-for-of": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0.tgz",
+            "integrity": "sha512-TlxKecN20X2tt2UEr2LNE6aqA0oPeMT1Y3cgz8k4Dn1j5ObT8M3nl9aA37LLklx0PBZKETC9ZAf9n/6SujTuXA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-function-name": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.0.0.tgz",
+            "integrity": "sha512-mR7JN9vkwsAIot74pSwzn/2Gq4nn2wN0HKtQyJLc1ghAarsymdBMTfh+Q/aeR2N3heXs3URQscTLrKe3yUU7Yw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-function-name": "^7.0.0",
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-literals": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0.tgz",
+            "integrity": "sha512-1NTDBWkeNXgpUcyoVFxbr9hS57EpZYXpje92zv0SUzjdu3enaRwF/l3cmyRnXLtIdyJASyiS6PtybK+CgKf7jA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-modules-amd": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.0.0.tgz",
+            "integrity": "sha512-CtSVpT/0tty/4405qczoIHm41YfFbPChplsmfBwsi3RTq/M9cHgVb3ixI5bqqgdKkqWwSX2sXqejvMKLuTVU+Q==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-transforms": "^7.0.0",
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-modules-commonjs": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.0.0.tgz",
+            "integrity": "sha512-BIcQLgPFCxi7YygtNpz5xj+7HxhOprbCGZKeLW6Kxsn1eHS6sJZMw4MfmqFZagl/v6IVa0AJoMHdDXLVrpd3Aw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-transforms": "^7.0.0",
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-simple-access": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-modules-systemjs": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.0.0.tgz",
+            "integrity": "sha512-8EDKMAsitLkiF/D4Zhe9CHEE2XLh4bfLbb9/Zf3FgXYQOZyZYyg7EAel/aT2A7bHv62jwHf09q2KU/oEexr83g==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-hoist-variables": "^7.0.0",
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-modules-umd": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.0.0.tgz",
+            "integrity": "sha512-EMyKpzgugxef+R1diXDwqw/Hmt5ls8VxfI8Gq5Lo8Qp3oKIepkYG4L/mvE2dmZSRalgL9sguoPKbnQ1m96hVFw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-transforms": "^7.0.0",
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-new-target": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0.tgz",
+            "integrity": "sha512-yin069FYjah+LbqfGeTfzIBODex/e++Yfa0rH0fpfam9uTbuEeEOx5GLGr210ggOV77mVRNoeqSYqeuaqSzVSw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-object-super": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.0.0.tgz",
+            "integrity": "sha512-BfAiF1l18Xr1shy1NyyQgLiHDvh/S7APiEM5+0wxTsQ+e3fgXO+NA47u4PvppzH0meJS21y0gZHcjnvUAJj8tQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-replace-supers": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-parameters": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.0.0.tgz",
+            "integrity": "sha512-eWngvRBWx0gScot0xa340JzrkA+8HGAk1OaCHDfXAjkrTFkp73Lcf+78s7AStSdRML5nzx5aXpnjN1MfrjkBoA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-call-delegate": "^7.0.0",
+                "@babel/helper-get-function-arity": "^7.0.0",
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-regenerator": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0.tgz",
+            "integrity": "sha512-sj2qzsEx8KDVv1QuJc/dEfilkg3RRPvPYx/VnKLtItVQRWt1Wqf5eVCOLZm29CiGFfYYsA3VPjfizTCV0S0Dlw==",
+            "dev": true,
+            "requires": {
+                "regenerator-transform": "^0.13.3"
+            }
+        },
+        "@babel/plugin-transform-shorthand-properties": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0.tgz",
+            "integrity": "sha512-g/99LI4vm5iOf5r1Gdxq5Xmu91zvjhEG5+yZDJW268AZELAu4J1EiFLnkSG3yuUsZyOipVOVUKoGPYwfsTymhw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-spread": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0.tgz",
+            "integrity": "sha512-L702YFy2EvirrR4shTj0g2xQp7aNwZoWNCkNu2mcoU0uyzMl0XRwDSwzB/xp6DSUFiBmEXuyAyEN16LsgVqGGQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-sticky-regex": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0.tgz",
+            "integrity": "sha512-LFUToxiyS/WD+XEWpkx/XJBrUXKewSZpzX68s+yEOtIbdnsRjpryDw9U06gYc6klYEij/+KQVRnD3nz3AoKmjw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-regex": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-template-literals": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0.tgz",
+            "integrity": "sha512-vA6rkTCabRZu7Nbl9DfLZE1imj4tzdWcg5vtdQGvj+OH9itNNB6hxuRMHuIY8SGnEt1T9g5foqs9LnrHzsqEFg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-annotate-as-pure": "^7.0.0",
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-typeof-symbol": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.0.0.tgz",
+            "integrity": "sha512-1r1X5DO78WnaAIvs5uC48t41LLckxsYklJrZjNKcevyz83sF2l4RHbw29qrCPr/6ksFsdfRpT/ZgxNWHXRnffg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0"
+            }
+        },
+        "@babel/plugin-transform-unicode-regex": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0.tgz",
+            "integrity": "sha512-uJBrJhBOEa3D033P95nPHu3nbFwFE9ZgXsfEitzoIXIwqAZWk7uXcg06yFKXz9FSxBH5ucgU/cYdX0IV8ldHKw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-regex": "^7.0.0",
+                "regexpu-core": "^4.1.3"
+            }
+        },
+        "@babel/preset-env": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.0.0.tgz",
+            "integrity": "sha512-Fnx1wWaWv2w2rl+VHxA9si//Da40941IQ29fKiRejVR7oN1FxSEL8+SyAX/2oKIye2gPvY/GBbJVEKQ/oi43zQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-imports": "^7.0.0",
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/plugin-proposal-async-generator-functions": "^7.0.0",
+                "@babel/plugin-proposal-json-strings": "^7.0.0",
+                "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+                "@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
+                "@babel/plugin-proposal-unicode-property-regex": "^7.0.0",
+                "@babel/plugin-syntax-async-generators": "^7.0.0",
+                "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+                "@babel/plugin-syntax-optional-catch-binding": "^7.0.0",
+                "@babel/plugin-transform-arrow-functions": "^7.0.0",
+                "@babel/plugin-transform-async-to-generator": "^7.0.0",
+                "@babel/plugin-transform-block-scoped-functions": "^7.0.0",
+                "@babel/plugin-transform-block-scoping": "^7.0.0",
+                "@babel/plugin-transform-classes": "^7.0.0",
+                "@babel/plugin-transform-computed-properties": "^7.0.0",
+                "@babel/plugin-transform-destructuring": "^7.0.0",
+                "@babel/plugin-transform-dotall-regex": "^7.0.0",
+                "@babel/plugin-transform-duplicate-keys": "^7.0.0",
+                "@babel/plugin-transform-exponentiation-operator": "^7.0.0",
+                "@babel/plugin-transform-for-of": "^7.0.0",
+                "@babel/plugin-transform-function-name": "^7.0.0",
+                "@babel/plugin-transform-literals": "^7.0.0",
+                "@babel/plugin-transform-modules-amd": "^7.0.0",
+                "@babel/plugin-transform-modules-commonjs": "^7.0.0",
+                "@babel/plugin-transform-modules-systemjs": "^7.0.0",
+                "@babel/plugin-transform-modules-umd": "^7.0.0",
+                "@babel/plugin-transform-new-target": "^7.0.0",
+                "@babel/plugin-transform-object-super": "^7.0.0",
+                "@babel/plugin-transform-parameters": "^7.0.0",
+                "@babel/plugin-transform-regenerator": "^7.0.0",
+                "@babel/plugin-transform-shorthand-properties": "^7.0.0",
+                "@babel/plugin-transform-spread": "^7.0.0",
+                "@babel/plugin-transform-sticky-regex": "^7.0.0",
+                "@babel/plugin-transform-template-literals": "^7.0.0",
+                "@babel/plugin-transform-typeof-symbol": "^7.0.0",
+                "@babel/plugin-transform-unicode-regex": "^7.0.0",
+                "browserslist": "^4.1.0",
+                "invariant": "^2.2.2",
+                "js-levenshtein": "^1.1.3",
+                "semver": "^5.3.0"
+            }
+        },
+        "@babel/register": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.0.0.tgz",
+            "integrity": "sha512-f/+CRmaCe7rVEvcvPvxeA8j5aJhHC3aJie7YuqcMDhUOuyWLA7J/aNrTaHIzoWPEhpHA54mec4Mm8fv8KBlv3g==",
+            "dev": true,
+            "requires": {
+                "core-js": "^2.5.7",
+                "find-cache-dir": "^1.0.0",
+                "home-or-tmp": "^3.0.0",
+                "lodash": "^4.17.10",
+                "mkdirp": "^0.5.1",
+                "pirates": "^4.0.0",
+                "source-map-support": "^0.5.9"
+            }
+        },
+        "@babel/template": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0.tgz",
+            "integrity": "sha512-VLQZik/G5mjYJ6u19U3W2u7eM+rA/NGzH+GtHDFFkLTKLW66OasFrxZ/yK7hkyQcswrmvugFyZpDFRW0DjcjCw==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@babel/parser": "^7.0.0",
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/traverse": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0.tgz",
+            "integrity": "sha512-ka/lwaonJZTlJyn97C4g5FYjPOx+Oxd3ab05hbDr1Mx9aP1FclJ+SUHyLx3Tx40sGmOVJApDxE6puJhd3ld2kw==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@babel/generator": "^7.0.0",
+                "@babel/helper-function-name": "^7.0.0",
+                "@babel/helper-split-export-declaration": "^7.0.0",
+                "@babel/parser": "^7.0.0",
+                "@babel/types": "^7.0.0",
+                "debug": "^3.1.0",
+                "globals": "^11.1.0",
+                "lodash": "^4.17.10"
+            }
+        },
+        "@babel/types": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0.tgz",
+            "integrity": "sha512-5tPDap4bGKTLPtci2SUl/B7Gv8RnuJFuQoWx26RJobS0fFrz4reUA3JnwIM+HVHEmWE0C1mzKhDtTp8NsWY02Q==",
+            "dev": true,
+            "requires": {
+                "esutils": "^2.0.2",
+                "lodash": "^4.17.10",
+                "to-fast-properties": "^2.0.0"
+            }
+        },
+        "ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dev": true,
+            "requires": {
+                "color-convert": "^1.9.0"
+            }
+        },
+        "balanced-match": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+            "dev": true
+        },
+        "brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "browserslist": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.1.1.tgz",
+            "integrity": "sha512-VBorw+tgpOtZ1BYhrVSVTzTt/3+vSE3eFUh0N2GCFK1HffceOaf32YS/bs6WiFhjDAblAFrx85jMy3BG9fBK2Q==",
+            "dev": true,
+            "requires": {
+                "caniuse-lite": "^1.0.30000884",
+                "electron-to-chromium": "^1.3.62",
+                "node-releases": "^1.0.0-alpha.11"
+            }
+        },
+        "buffer-from": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+            "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+            "dev": true
+        },
+        "caniuse-lite": {
+            "version": "1.0.30000885",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000885.tgz",
+            "integrity": "sha512-cXKbYwpxBLd7qHyej16JazPoUacqoVuDhvR61U7Fr5vSxMUiodzcYa1rQYRYfZ5GexV03vGZHd722vNPLjPJGQ==",
+            "dev": true
+        },
+        "chalk": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+            "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            }
+        },
+        "color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dev": true,
+            "requires": {
+                "color-name": "1.1.3"
+            }
+        },
+        "color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+            "dev": true
+        },
+        "commondir": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+            "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+            "dev": true
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
+        },
+        "convert-source-map": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+            "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "~5.1.1"
+            }
+        },
+        "core-js": {
+            "version": "2.5.7",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+            "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
+            "dev": true
+        },
+        "debug": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+            "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+            "dev": true,
+            "requires": {
+                "ms": "2.0.0"
+            }
+        },
+        "electron-to-chromium": {
+            "version": "1.3.64",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.64.tgz",
+            "integrity": "sha512-CU5ta5MbzRre+WhzKfPBM3HlyZGM7bwNKmiByzFzCfxP3q7cNmGLKopq5Q+LGXza69aIHXk2sZZSh/Oh7TKPIQ==",
+            "dev": true
+        },
+        "escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "dev": true
+        },
+        "esutils": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+            "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+            "dev": true
+        },
+        "find-cache-dir": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
+            "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
+            "dev": true,
+            "requires": {
+                "commondir": "^1.0.1",
+                "make-dir": "^1.0.0",
+                "pkg-dir": "^2.0.0"
+            }
+        },
+        "find-up": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+            "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+            "dev": true,
+            "requires": {
+                "locate-path": "^2.0.0"
+            }
+        },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
+        },
+        "glob": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+            "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+            "dev": true,
+            "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            }
+        },
+        "globals": {
+            "version": "11.7.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
+            "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
+            "dev": true
+        },
+        "has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+            "dev": true
+        },
+        "home-or-tmp": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-3.0.0.tgz",
+            "integrity": "sha1-V6j+JM8zzdUkhgoVgh3cJchmcfs=",
+            "dev": true
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true,
+            "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "inherits": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+            "dev": true
+        },
+        "invariant": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+            "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+            "dev": true,
+            "requires": {
+                "loose-envify": "^1.0.0"
+            }
+        },
+        "jasmine": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-3.2.0.tgz",
+            "integrity": "sha512-qv6TZ32r+slrQz8fbx2EhGbD9zlJo3NwPrpLK1nE8inILtZO9Fap52pyHk7mNTh4tG50a+1+tOiWVT3jO5I0Sg==",
+            "dev": true,
+            "requires": {
+                "glob": "^7.0.6",
+                "jasmine-core": "~3.2.0"
+            }
+        },
+        "jasmine-core": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.2.1.tgz",
+            "integrity": "sha512-pa9tbBWgU0EE4SWgc85T4sa886ufuQdsgruQANhECYjwqgV4z7Vw/499aCaP8ZH79JDS4vhm8doDG9HO4+e4sA==",
+            "dev": true
+        },
+        "js-levenshtein": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.3.tgz",
+            "integrity": "sha512-/812MXr9RBtMObviZ8gQBhHO8MOrGj8HlEE+4ccMTElNA/6I3u39u+bhny55Lk921yn44nSZFy9naNLElL5wgQ==",
+            "dev": true
+        },
+        "js-tokens": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "dev": true
+        },
+        "jsesc": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
+            "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
+            "dev": true
+        },
+        "json5": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+            "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+            "dev": true
+        },
+        "locate-path": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+            "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+            "dev": true,
+            "requires": {
+                "p-locate": "^2.0.0",
+                "path-exists": "^3.0.0"
+            }
+        },
+        "lodash": {
+            "version": "4.17.10",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+            "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+            "dev": true
+        },
+        "loose-envify": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+            "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+            "dev": true,
+            "requires": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+            }
+        },
+        "make-dir": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+            "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+            "dev": true,
+            "requires": {
+                "pify": "^3.0.0"
+            }
+        },
+        "minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dev": true,
+            "requires": {
+                "brace-expansion": "^1.1.7"
+            }
+        },
+        "minimist": {
+            "version": "0.0.8",
+            "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+            "dev": true
+        },
+        "mkdirp": {
+            "version": "0.5.1",
+            "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "dev": true,
+            "requires": {
+                "minimist": "0.0.8"
+            }
+        },
+        "ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+            "dev": true
+        },
+        "node-modules-regexp": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
+            "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
+            "dev": true
+        },
+        "node-releases": {
+            "version": "1.0.0-alpha.11",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.0.0-alpha.11.tgz",
+            "integrity": "sha512-CaViu+2FqTNYOYNihXa5uPS/zry92I3vPU4nCB6JB3OeZ2UGtOpF5gRwuN4+m3hbEcL47bOXyun1jX2iC+3uEQ==",
+            "dev": true,
+            "requires": {
+                "semver": "^5.3.0"
+            }
+        },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
+            "requires": {
+                "wrappy": "1"
+            }
+        },
+        "p-limit": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+            "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+            "dev": true,
+            "requires": {
+                "p-try": "^1.0.0"
+            }
+        },
+        "p-locate": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+            "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+            "dev": true,
+            "requires": {
+                "p-limit": "^1.1.0"
+            }
+        },
+        "p-try": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+            "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+            "dev": true
+        },
+        "path-exists": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+            "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+            "dev": true
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true
+        },
+        "path-parse": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+            "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+            "dev": true
+        },
+        "pify": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+            "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+            "dev": true
+        },
+        "pirates": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.0.tgz",
+            "integrity": "sha512-8t5BsXy1LUIjn3WWOlOuFDuKswhQb/tkak641lvBgmPOBUQHXveORtlMCp6OdPV1dtuTaEahKA8VNz6uLfKBtA==",
+            "dev": true,
+            "requires": {
+                "node-modules-regexp": "^1.0.0"
+            }
+        },
+        "pkg-dir": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+            "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+            "dev": true,
+            "requires": {
+                "find-up": "^2.1.0"
+            }
+        },
+        "private": {
+            "version": "0.1.8",
+            "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+            "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+            "dev": true
+        },
+        "regenerate": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+            "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
+            "dev": true
+        },
+        "regenerate-unicode-properties": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-7.0.0.tgz",
+            "integrity": "sha512-s5NGghCE4itSlUS+0WUj88G6cfMVMmH8boTPNvABf8od+2dhT9WDlWu8n01raQAJZMOK8Ch6jSexaRO7swd6aw==",
+            "dev": true,
+            "requires": {
+                "regenerate": "^1.4.0"
+            }
+        },
+        "regenerator-transform": {
+            "version": "0.13.3",
+            "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.13.3.tgz",
+            "integrity": "sha512-5ipTrZFSq5vU2YoGoww4uaRVAK4wyYC4TSICibbfEPOruUu8FFP7ErV0BjmbIOEpn3O/k9na9UEdYR/3m7N6uA==",
+            "dev": true,
+            "requires": {
+                "private": "^0.1.6"
+            }
+        },
+        "regexpu-core": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.2.0.tgz",
+            "integrity": "sha512-Z835VSnJJ46CNBttalHD/dB+Sj2ezmY6Xp38npwU87peK6mqOzOpV8eYktdkLTEkzzD+JsTcxd84ozd8I14+rw==",
+            "dev": true,
+            "requires": {
+                "regenerate": "^1.4.0",
+                "regenerate-unicode-properties": "^7.0.0",
+                "regjsgen": "^0.4.0",
+                "regjsparser": "^0.3.0",
+                "unicode-match-property-ecmascript": "^1.0.4",
+                "unicode-match-property-value-ecmascript": "^1.0.2"
+            }
+        },
+        "regjsgen": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.4.0.tgz",
+            "integrity": "sha512-X51Lte1gCYUdlwhF28+2YMO0U6WeN0GLpgpA7LK7mbdDnkQYiwvEpmpe0F/cv5L14EbxgrdayAG3JETBv0dbXA==",
+            "dev": true
+        },
+        "regjsparser": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.3.0.tgz",
+            "integrity": "sha512-zza72oZBBHzt64G7DxdqrOo/30bhHkwMUoT0WqfGu98XLd7N+1tsy5MJ96Bk4MD0y74n629RhmrGW6XlnLLwCA==",
+            "dev": true,
+            "requires": {
+                "jsesc": "~0.5.0"
+            },
+            "dependencies": {
+                "jsesc": {
+                    "version": "0.5.0",
+                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+                    "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+                    "dev": true
+                }
+            }
+        },
+        "resolve": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+            "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+            "dev": true,
+            "requires": {
+                "path-parse": "^1.0.5"
+            }
+        },
+        "safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true
+        },
+        "semver": {
+            "version": "5.5.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
+            "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
+            "dev": true
+        },
+        "source-map": {
+            "version": "0.5.7",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+            "dev": true
+        },
+        "source-map-support": {
+            "version": "0.5.9",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
+            "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
+            "dev": true,
+            "requires": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "supports-color": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "dev": true,
+            "requires": {
+                "has-flag": "^3.0.0"
+            }
+        },
+        "to-fast-properties": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+            "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+            "dev": true
+        },
+        "trim-right": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+            "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+            "dev": true
+        },
+        "unicode-canonical-property-names-ecmascript": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+            "integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
+            "dev": true
+        },
+        "unicode-match-property-ecmascript": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+            "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
+            "dev": true,
+            "requires": {
+                "unicode-canonical-property-names-ecmascript": "^1.0.4",
+                "unicode-property-aliases-ecmascript": "^1.0.4"
+            }
+        },
+        "unicode-match-property-value-ecmascript": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.0.2.tgz",
+            "integrity": "sha512-Rx7yODZC1L/T8XKo/2kNzVAQaRE88AaMvI1EF/Xnj3GW2wzN6fop9DDWuFAKUVFH7vozkz26DzP0qyWLKLIVPQ==",
+            "dev": true
+        },
+        "unicode-property-aliases-ecmascript": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.4.tgz",
+            "integrity": "sha512-2WSLa6OdYd2ng8oqiGIWnJqyFArvhn+5vgx5GTxMbUYjCYKUcuKS62YLFF0R/BDGlB1yzXjQOLtPAfHsgirEpg==",
+            "dev": true
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,16 +1,19 @@
 {
-    "name": "degjs-easing",
-    "version": "1.0.2",
+    "name": "@degjs/easing",
+    "version": "2.0.0",
     "description": "Animation easing functions",
     "keywords": [
-    	"easing",
-    	"animation",
+        "easing",
+        "animation",
         "DEGJS"
     ],
     "author": {
         "name": "Ryan Heap",
         "email": "rheap@degdigital.com"
     },
+    "files": [
+        "src"
+    ],
     "main": "src/easing.js",
     "license": "MIT",
     "repository": {
@@ -18,12 +21,14 @@
         "url": "https://github.com/DEGJS/easing.git"
     },
     "bugs": "https://github.com/DEGJS/easing/issues",
-    "jspm": {
-        "registry": "jspm",
-        "format": "es6",
-        "main": "easing.js",
-        "directories": {
-            "lib": "src"
-        }
-    }
+    "devDependencies": {
+        "@babel/core": "^7.0.0",
+        "@babel/preset-env": "^7.0.0",
+        "@babel/register": "^7.0.0",
+        "jasmine": "^3.2.0"
+    },
+    "scripts": {
+        "test": "jasmine"
+    },
+    "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
         "src"
     ],
     "main": "src/easing.js",
+    "publishConfig": { "access": "public" },
     "license": "MIT",
     "repository": {
         "type": "git",

--- a/spec/easing-spec.js
+++ b/spec/easing-spec.js
@@ -1,0 +1,29 @@
+const easing = require('../src/easing');
+
+describe("Calling the linear function", function() {
+    it("should return the expected value", function() {
+        const value = easing.linear(1, 1, 5, 10);
+        expect(value).toBe(1.5);
+    });
+});
+
+describe("Calling the easeInOutCubic function", function() {
+    it("should return the expected value", function() {
+        const value = easing.easeInOutCubic(1, 1, 5, 10);
+        expect(value).toBe(1.02);
+    });
+});
+
+describe("Calling the easeOutCubic function", function() {
+    it("should return the expected value", function() {
+        const value = easing.easeOutCubic(1, 1, 5, 10);
+        expect(value).toBe(2.3549999999999995);
+    });
+});
+
+describe("Calling the easeInCubic function", function() {
+    it("should return the expected value", function() {
+        const value = easing.easeInCubic(1, 1, 5, 10);
+        expect(value).toBe(1.005);
+    });
+});

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,0 +1,12 @@
+{
+  "spec_dir": "spec",
+  "spec_files": [
+    "**/*[sS]pec.js"
+  ],
+  "helpers": [
+    "helpers/**/*.js",
+    "../node_modules/@babel/register/lib/node.js"
+  ],
+  "stopSpecOnExpectationFailure": false,
+  "random": true
+}


### PR DESCRIPTION
Added unit tests, removed JSPM metadata from package.json, and did a major version bump so as not to interfere with existing JSPM projects that are using this package.

For a testing framework, I went with Jasmine instead of Jest. It's a similar syntax, plus this package has no user interface (web or otherwise), so Jest seemed like overkill.

Also, in the package.json: I added a `files` attribute so that only the `src` directory gets included when someone installs this package via npm. There is no `dist` directory for this package, but there could be. It could include things like a minified version of the `src/easing.js` file, a transpiled version, etc. I'm open to suggestions.